### PR TITLE
Enable tools to search using source metadata

### DIFF
--- a/service.py
+++ b/service.py
@@ -107,8 +107,6 @@ service = Service(
 # ============================================================================
 # REQUEST / RESPONSE MODELS
 # ============================================================================
-meter = metrics.get_meter("ivcap.service.crewai")
-success_counter = meter.create_counter("request_success_count", description="Counts successful crew executions")
 
 class CrewRequest(BaseModel):
     """Request to execute a CrewAI crew."""
@@ -843,7 +841,6 @@ async def crew_runner(req: CrewRequest, jobCtxt: JobContext) -> CrewResponse:
             f"{len(response.task_responses)} tasks"
         )
         logger.info("\n\n %s", response)
-        success_counter.add(1)
         return response
 
     finally:

--- a/service.py
+++ b/service.py
@@ -826,7 +826,7 @@ async def crew_runner(req: CrewRequest, jobCtxt: JobContext) -> CrewResponse:
             crew_name=req.name,
             place_holders=[],
             task_responses=[
-                # TaskResponse.from_task_output(r) for r in crew_result.tasks_output
+                TaskResponse.from_task_output(r) for r in crew_result.tasks_output
             ],
             created_at=datetime.datetime.now()
             .astimezone()

--- a/service.py
+++ b/service.py
@@ -826,7 +826,7 @@ async def crew_runner(req: CrewRequest, jobCtxt: JobContext) -> CrewResponse:
             crew_name=req.name,
             place_holders=[],
             task_responses=[
-                TaskResponse.from_task_output(r) for r in crew_result.tasks_output
+                # TaskResponse.from_task_output(r) for r in crew_result.tasks_output
             ],
             created_at=datetime.datetime.now()
             .astimezone()

--- a/service.py
+++ b/service.py
@@ -74,7 +74,7 @@ from tools.search import WebsiteSearchToolWithLinks, SerperDevToolWithLinks
 from tools.helpers import ResilientPDFSearchTool, ResilientWebsiteSearchTool
 from tools.url_metadata_extractor import URLMetadataExtractor
 from download_manager import DownloadManager, DownloadResult
-from opentelemetry import metrics
+
 
 # Initialize logging
 load_dotenv()

--- a/service.py
+++ b/service.py
@@ -74,6 +74,7 @@ from tools.search import WebsiteSearchToolWithLinks, SerperDevToolWithLinks
 from tools.helpers import ResilientPDFSearchTool, ResilientWebsiteSearchTool
 from tools.url_metadata_extractor import URLMetadataExtractor
 from download_manager import DownloadManager, DownloadResult
+from opentelemetry import metrics
 
 # Initialize logging
 load_dotenv()
@@ -106,7 +107,8 @@ service = Service(
 # ============================================================================
 # REQUEST / RESPONSE MODELS
 # ============================================================================
-
+meter = metrics.get_meter("ivcap.service.crewai")
+success_counter = meter.create_counter("request_success_count", description="Counts successful crew executions")
 
 class CrewRequest(BaseModel):
     """Request to execute a CrewAI crew."""
@@ -841,7 +843,7 @@ async def crew_runner(req: CrewRequest, jobCtxt: JobContext) -> CrewResponse:
             f"{len(response.task_responses)} tasks"
         )
         logger.info("\n\n %s", response)
-
+        success_counter.add(1)
         return response
 
     finally:

--- a/service_types.py
+++ b/service_types.py
@@ -371,6 +371,7 @@ class CrewA(BaseModel):
         return crew
 
 class TaskResponse(BaseModel):
+    jschema: str = Field("urn:sd-core:schema.crewai.taskresponse.1", alias="$schema")
     agent: str
     description: str
     summary: str

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -1,47 +1,140 @@
 from crewai_tools import PDFSearchTool, WebsiteSearchTool
+from pydantic import model_validator
+from typing_extensions import Self
 
 from ivcap_service import getLogger
 
+from tools.source_ref_rag_adapter import SourceRefRagAdapter
+
 logger = getLogger(__name__)
 
-class ResilientPDFSearchTool(PDFSearchTool):
+
+class _SourceRefAdapterMixin:
+    """Mixin for RagTool-based tools that scopes searches to a single source.
+
+    Two things are needed to filter a RagTool search by source:
+
+    1. The adapter must accept a source filter. RagTool builds a plain
+       ``CrewAIRagAdapter`` whose ``query()`` ignores metadata, so
+       ``_use_source_ref_adapter`` swaps in :class:`SourceRefRagAdapter`, whose
+       ``query()`` takes a ``source_ref`` and forwards it as
+       ``metadata_filter={"source": source_ref}``.
+    2. The ``source_ref`` must actually reach ``adapter.query()``. ``RagTool._run``
+       (and the parent tools' ``_run``) only pass ``query``/``similarity_threshold``/
+       ``limit`` — they drop the pdf/website. So each tool overrides ``_run`` and
+       routes through :meth:`_query_with_source`, which mirrors ``RagTool._run``
+       but additionally passes ``source_ref``.
+
+    The mixin exists because the tools it serves extend different parents
+    (``PDFSearchTool`` vs ``WebsiteSearchTool``), so a shared base class isn't
+    available.
+    """
+
+    @model_validator(mode="after")
+    def _use_source_ref_adapter(self) -> Self:
+        if not isinstance(self.adapter, SourceRefRagAdapter):
+            provider_cfg = self._parse_config(self.config)
+            self.adapter = SourceRefRagAdapter(
+                collection_name=self.collection_name,
+                summarize=self.summarize,
+                similarity_threshold=self.similarity_threshold,
+                limit=self.limit,
+                config=provider_cfg,
+            )
+        return self
+
+    def _query_with_source(
+        self,
+        query: str,
+        source_ref: str | None,
+        similarity_threshold: float | None = None,
+        limit: int | None = None,
+    ) -> str:
+        """Run a RagTool query scoped to ``source_ref``.
+
+        Replaces ``RagTool._run`` (same threshold/limit defaulting and
+        "Relevant Content:" wrapper) but forwards ``source_ref`` to the adapter
+        so the search is restricted to that source. A ``source_ref`` of ``None``
+        means no filter (collection-wide search, i.e. base behaviour).
+        """
+        threshold = (
+            similarity_threshold
+            if similarity_threshold is not None
+            else self.similarity_threshold
+        )
+        result_limit = limit if limit is not None else self.limit
+        content = self.adapter.query(
+            query,
+            similarity_threshold=threshold,
+            limit=result_limit,
+            source_ref=source_ref,
+        )
+        return f"Relevant Content:\n{content}"
+
+
+class ResilientPDFSearchTool(_SourceRefAdapterMixin, PDFSearchTool):
     """
     A resilient version of the PDFSearchTool that catches errors
     and guides the agent instead of crashing the script.
+
+    Queries are scoped to the PDF being searched: the ``pdf`` arg is the value
+    stored under the ``"source"`` metadata key on add(), so it is forwarded to
+    the adapter to keep results accurate when several PDFs share one collection.
     """
-    def _run(self, *args, **kwargs):
+
+    def _run(
+        self,
+        query: str,
+        pdf: str | None = None,
+        similarity_threshold: float | None = None,
+        limit: int | None = None,
+    ) -> str:
         try:
-            logger.info("[🔍 Searching PDF with args: %s]", kwargs)
-            # Execute the original tool's logic
-            return super()._run(*args, **kwargs)
-            
+            logger.info("[🔍 Searching PDF: %s | query: %s]", pdf, query)
+            # When bound to a fixed PDF at construction the agent passes only
+            # `query`; fall back to the stored pdf in that case.
+            source_ref = pdf if pdf is not None else self.pdf
+            if pdf is not None:
+                self.add(pdf)
+            return self._query_with_source(query, source_ref, similarity_threshold, limit)
+
         except Exception as e:
             error_msg = str(e)
             logger.error("[❌ PDF Search Failed: %s]", error_msg)
-            
-            # Return the error as a string with guidance
             return (
                 f"SYSTEM ERROR IN PDF SEARCH: {error_msg}. \n"
                 f"THOUGHT GUIDANCE: The search failed. Please rephrase your "
                 f"search query, use different keywords, otherwise return the final answer based on the information you have. Do not attempt to search again."
             )
-        
-class ResilientWebsiteSearchTool(WebsiteSearchTool):
+
+
+class ResilientWebsiteSearchTool(_SourceRefAdapterMixin, WebsiteSearchTool):
     """
     A resilient version of the WebsiteSearchTool that catches errors
     and guides the agent instead of crashing the script.
+
+    Queries are scoped to the website being searched: the ``website`` arg is the
+    value stored under the ``"source"`` metadata key on add(), so it is
+    forwarded to the adapter to keep results accurate when several sites share
+    one collection.
     """
-    def _run(self, *args, **kwargs):
+
+    def _run(
+        self,
+        search_query: str,
+        website: str | None = None,
+        similarity_threshold: float | None = None,
+        limit: int | None = None,
+    ) -> str:
         try:
-            logger.info("[🔍 Searching website with args: %s]", kwargs)
-            # Execute the original tool's logic
-            return super()._run(*args, **kwargs)
-            
+            logger.info("[🔍 Searching website: %s | query: %s]", website, search_query)
+            if website is not None:
+                self.add(website)
+            return self._query_with_source(search_query, website, similarity_threshold, limit)
+
         except Exception as e:
             error_msg = str(e)
             logger.error("[❌ Website Search Failed: %s]", error_msg)
-            
-            # Return the error as a string with guidance
             return (
                 f"SYSTEM ERROR IN WEBSITE SEARCH: {error_msg}. \n"
                 f"THOUGHT GUIDANCE: The search failed. Please rephrase your "

--- a/tools/source_ref_rag_adapter.py
+++ b/tools/source_ref_rag_adapter.py
@@ -1,0 +1,88 @@
+"""RAG adapter that scopes queries to a specific source reference.
+
+``CrewAIRagAdapter`` records the original source of every chunk it stores under
+the ``"source"`` metadata key (see ``CrewAIRagAdapter.add`` →
+``chunk_metadata["source"] = source_ref``). Its ``query()`` method, however,
+never forwards a metadata filter to the underlying vector store, so a search
+always spans every source in the collection — even though the client
+(``BaseClient.search``) accepts a ``metadata_filter``.
+
+This subclass overrides ``query()`` so a search can be restricted to a single
+source. The ``source_ref`` is passed through as
+``metadata_filter={"source": source_ref}`` — the same key ``add()`` writes — so
+only chunks originating from that source are returned. This keeps results
+accurate when several documents share one collection.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from crewai.rag.types import SearchResult
+from crewai_tools.adapters.crewai_rag_adapter import CrewAIRagAdapter
+
+# Metadata key under which CrewAIRagAdapter.add() records the source reference.
+SOURCE_METADATA_KEY = "source"
+
+
+class SourceRefRagAdapter(CrewAIRagAdapter):
+    """CrewAIRagAdapter that can scope queries to a given ``source_ref``.
+
+    The source reference may be set on the instance (``source_ref``, applied to
+    every query) or supplied per call to :meth:`query`; a per-call value takes
+    precedence. When present it is forwarded to the client as
+    ``metadata_filter={"source": source_ref}``; when absent the query behaves
+    exactly like the base adapter.
+    """
+
+    # source_ref: str | None = None
+
+    def query(
+        self,
+        question: str,
+        similarity_threshold: float | None = None,
+        limit: int | None = None,
+        source_ref: str | None = None,
+    ) -> str:
+        """Query the knowledge base, optionally filtered by source reference.
+
+        Args:
+            question: The question to ask.
+            similarity_threshold: Minimum similarity score for results
+                (default: ``self.similarity_threshold``).
+            limit: Maximum number of results to return (default: ``self.limit``).
+            source_ref: Restrict results to chunks whose ``"source"`` metadata
+                equals this value. Overrides the instance-level ``source_ref``.
+
+        Returns:
+            Relevant content from the knowledge base, joined by blank lines.
+        """
+        search_limit = limit if limit is not None else self.limit
+        search_threshold = (
+            similarity_threshold
+            if similarity_threshold is not None
+            else self.similarity_threshold
+        )
+        if self._client is None:
+            raise ValueError("Client is not initialized")
+
+        params = {
+            "collection_name": self.collection_name,
+            "query": question,
+            "limit": search_limit,
+            "score_threshold": search_threshold,
+        }
+        if source_ref:
+            params["metadata_filter"] = {SOURCE_METADATA_KEY: source_ref}
+
+        results: list[SearchResult] = self._client.search(**params)
+
+        if not results:
+            return "No relevant content found."
+
+        contents: list[str] = []
+        for result in results:
+            content: str = result.get("content", "")
+            if content:
+                contents.append(content)
+
+        return "\n\n".join(contents)


### PR DESCRIPTION
Allow to use the source metadata in crew ai tools. 
Allow to embed the source metadata when adding websites or pdf documents.
Allow to query using the source metadata when querying content.